### PR TITLE
fix: Update Codecov to v5 and fix missing coverage reports

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -73,11 +73,11 @@ jobs:
         fi
         
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       if: ${{ secrets.CODECOV_TOKEN != '' }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: pr-${{ github.event.pull_request.number }}
         fail_ci_if_error: false


### PR DESCRIPTION
## Problem

Coverage reports were not appearing in Codecov despite having the  secret configured. The issue was identified as using outdated codecov-action@v4 instead of the current v5.

## Root Cause Analysis

1. **Version mismatch**: Using codecov-action@v4 instead of v5 
2. **Parameter change**: v5 uses `files` instead of `file` parameter
3. **Token configured**: CODECOV_TOKEN secret is properly set up (created 2025-09-06)

## Solution

### Updated Codecov Configuration
- **Upgrade**: codecov-action@v4 → codecov-action@v5
- **Parameter fix**: `file: ./coverage.xml` → `files: ./coverage.xml`
- **Maintained**: All existing error handling and token checks

### Verified Configuration  
- ✅ CODECOV_TOKEN secret exists in repository
- ✅ Token availability check preserved 
- ✅ Coverage XML generation working (coverage.xml)
- ✅ Fail-safe behavior maintained (continue-on-error: true)

## Expected Impact

- ✅ **Coverage reports**: Should now appear in Codecov dashboard
- ✅ **PR integration**: Coverage diffs should show in PR comments  
- ✅ **Maintained stability**: Existing error handling preserved
- ✅ **No breaking changes**: Same workflow behavior

## Testing

The next PR will test the updated Codecov integration with v5 action and proper parameter configuration.