### PR TITLE
fix: Correct import paths causing test failures

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,6 +1,4 @@
 # Configuration module
-from .config_manager import ConfigManager
-from .app_config import AppConfig
-from .document_processing_config import DocumentProcessingConfig
+from .config_manager import ConfigManager, AppConfig, DocumentProcessingConfig
 
 __all__ = ['ConfigManager', 'AppConfig', 'DocumentProcessingConfig']


### PR DESCRIPTION
## Problem

Tests are failing with import errors:

```
ModuleNotFoundError: No module named 'src.config.app_config'
```

This was caused by my previous fix that incorrectly assumed `AppConfig` and `DocumentProcessingConfig` were in separate files.

## Root Cause

In my previous import fix, I incorrectly tried to import:
- `from .app_config import AppConfig` ❌
- `from .document_processing_config import DocumentProcessingConfig` ❌

But these classes are actually defined in `config_manager.py`:
- `class AppConfig` (line in config_manager.py)
- `class DocumentProcessingConfig` (line in config_manager.py) 
- `class ConfigManager` (line in config_manager.py)

## Solution

**Fixed src/config/__init__.py**:
```python
# Before (incorrect)
from .config_manager import ConfigManager
from .app_config import AppConfig  # ❌ This file doesn't exist
from .document_processing_config import DocumentProcessingConfig  # ❌ This file doesn't exist

# After (correct)  
from .config_manager import ConfigManager, AppConfig, DocumentProcessingConfig
```

## Validation

✅ **Local testing**: Imports work correctly locally:
```bash
python -c "from src.config import ConfigManager; from src.core import FileProcessor; print('✅ Imports working')"
# Output: ✅ Imports working
```

## Expected Impact

- ✅ **Tests should pass**: Resolves the ModuleNotFoundError  
- ✅ **Docker health checks**: Should now work correctly
- ✅ **No functionality change**: Same classes, correct import paths

This is a quick fix to correct the import structure I misunderstood in the previous PR.