### PR TITLE
fix: Use environment variable for CODECOV_TOKEN conditional check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,9 @@ jobs:
         
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: ${{ secrets.CODECOV_TOKEN }}
+      if: ${{ env.CODECOV_TOKEN != '' }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml


### PR DESCRIPTION
## Summary
Final fix for the GitHub Actions deployment workflow syntax error that was preventing deployment runs.

## Issue
The deployment workflow was still failing with:
```
Invalid workflow file: .github/workflows/deploy.yml#L1
(Line: 98, Col: 11): Unrecognized named-value: 'secrets'
```

## Root Cause
GitHub Actions doesn't allow direct `secrets` access in `if` conditionals. The syntax:
```yaml
if: ${{ secrets.CODECOV_TOKEN }}  # ❌ Not allowed
```

## Solution
Use environment variable approach:
```yaml
if: ${{ env.CODECOV_TOKEN != '' }}  # ✅ Correct
env:
  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
```

## Changes
- **Line 98**: Changed conditional from `secrets.CODECOV_TOKEN` to `env.CODECOV_TOKEN != ''`
- **Lines 99-100**: Added `env` mapping for CODECOV_TOKEN

## Validation
- ✅ YAML syntax validation passes
- ✅ IDE diagnostics clear (no more "Unrecognized named-value" error)  
- ✅ Follows GitHub Actions best practices for secrets in conditionals

This should resolve the instant deployment failures and allow the Codecov integration to work properly.

🤖 Generated with [Claude Code](https://claude.ai/code)