### PR TITLE
fix: Correct GHCR repository name in deploy script

### DIFF
--- a/docker_deployment_from_ghcr/deploy-ghcr.sh
+++ b/docker_deployment_from_ghcr/deploy-ghcr.sh
@@ -54,7 +54,7 @@ fi
 # Set default values (can be overridden by command line arguments)
 IMAGE_TAG="${1:-latest}"
 MODEL_VENDOR="${2:-google}"
-GHCR_REPO="${3:-ghcr.io/ronsonw/kiro-project}"
+GHCR_REPO="${3:-ghcr.io/ronsonw/rag-file-processor}"
 
 echo "  Docker image: $GHCR_REPO:$IMAGE_TAG"
 echo "  Model vendor: $MODEL_VENDOR"


### PR DESCRIPTION
## Summary
- Fixes incorrect repository name in GHCR deployment script
- Updates `ghcr.io/ronsonw/kiro-project` to `ghcr.io/ronsonw/rag-file-processor`
- Aligns deploy script with GitHub Actions workflow configuration

## Problem
The deploy-ghcr.sh script was trying to pull from `ghcr.io/ronsonw/kiro-project:latest` but the GitHub Actions workflow publishes to `ghcr.io/ronsonw/rag-file-processor:latest`.

## Solution
Updated line 57 in `docker_deployment_from_ghcr/deploy-ghcr.sh` to use the correct repository name that matches the workflow.

## Test plan
- [x] Verify script change matches GitHub Actions IMAGE_NAME
- [ ] Test deployment after workflow publishes image to GHCR

🤖 Generated with [Claude Code](https://claude.ai/code)