### PR TITLE
fix: Correct GitHub repository owner in GHCR deploy script

### DIFF
--- a/docker_deployment_from_ghcr/deploy-ghcr.sh
+++ b/docker_deployment_from_ghcr/deploy-ghcr.sh
@@ -54,7 +54,7 @@ fi
 # Set default values (can be overridden by command line arguments)
 IMAGE_TAG="${1:-latest}"
 MODEL_VENDOR="${2:-google}"
-GHCR_REPO="${3:-ghcr.io/ronsonw/rag-file-processor}"
+GHCR_REPO="${3:-ghcr.io/rwuniard/rag-file-processor}"
 
 echo "  Docker image: $GHCR_REPO:$IMAGE_TAG"
 echo "  Model vendor: $MODEL_VENDOR"


### PR DESCRIPTION
Updates the deploy-ghcr.sh script to use the correct repository owner 'rwuniard' instead of 'ronsonw' to match the actual GitHub repository structure and GitHub Actions workflow configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)