### PR TITLE
Critical CI/CD fixes and version update

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -101,7 +101,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ inputs.push_image == 'true' && format('{0}/{1}/{2}', inputs.registry, github.repository_owner, inputs.image_name) || inputs.image_name }}
+        images: ${{ format('{0}/{1}/{2}', inputs.registry, github.repository_owner, inputs.image_name) }}
         tags: |
           type=raw,value=latest,enable=${{ inputs.push_image == 'true' }}
           type=raw,value=${{ inputs.version }}
@@ -134,10 +134,7 @@ jobs:
         # Only load locally for production builds (deploy workflow)
         # PR validation just validates the build succeeds without loading the huge image
         load: ${{ inputs.push_image == true }}
-        tags: |
-          ${{ steps.meta.outputs.tags }}
-          ${{ inputs.image_name }}:${{ inputs.version }}
-          ${{ inputs.image_name }}:latest
+        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           VERSION=${{ inputs.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kiro-project"
-version = "0.1.0"
+version = "0.1.1"
 description = "Folder file processor application"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1344,7 +1344,7 @@ wheels = [
 
 [[package]]
 name = "kiro-project"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Critical fixes for CI/CD pipeline issues discovered after Docker reorganization merge, plus version update for package testing.

## 🔧 Critical Fixes

### CI/CD Pipeline Fixes
- **Docker Authentication**: Fixed scope error preventing GHCR authentication
  - Always use GHCR registry prefix instead of defaulting to Docker Hub
  - Eliminates "access token has insufficient scopes" error
- **Workflow Path Updates**: Updated CI paths after reorganization
  - Fixed generate_env.py path: scripts/ → shared/scripts/  
  - Fixed Dockerfile path: docker_deployment/ → docker_deployment/shared/
- **Workflow Syntax**: Resolved env context variable usage in reusable workflows
- **Security Scanning**: Switched from Safety to pip-audit, then back to Safety with API key

### Package Testing  
- **Version Update**: Updated version to trigger new GHCR package build
- **Lock File Update**: Updated uv.lock to ensure consistent dependencies

## 🚨 Issues Resolved
- ✅ "can't open file generate_env.py [Errno 2]" - CI path fix
- ✅ "access token has insufficient scopes" - Docker authentication fix  
- ✅ "Unrecognized named-value: 'env'" - Workflow syntax fix
- ✅ "EOF when reading a line" - Security scan authentication fix

## 🧪 Testing
- All fixes tested through iterative CI runs
- New version should trigger fresh GHCR package build
- Pipeline now properly authenticated and functional

These are critical hotfixes needed for the CI/CD system to function properly after the Docker reorganization.

🤖 Generated with [Claude Code](https://claude.ai/code)