### PR TITLE
fix: correct Python script indentation in Docker image test

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -170,21 +170,21 @@ jobs:
             -e ENABLE_DOCUMENT_PROCESSING=false \
             "$REGISTRY_TAG" \
             python -c "
-          import sys
-          print('🐍 Python version:', sys.version)
-          print('🏷️ Image version: ${{ inputs.version }}')
-          
-          try:
-              from src.app import FolderFileProcessorApp
-              from src.config import ConfigManager
-              from src.core import FileProcessor
-              print('✅ Core modules import successfully')
-          except ImportError as e:
-              print(f'❌ Import error: {e}')
-              sys.exit(1)
-              
-          print('✅ Docker registry image test passed')
-          "
+import sys
+print('🐍 Python version:', sys.version)
+print('🏷️ Image version: ${{ inputs.version }}')
+
+try:
+    from src.app import FolderFileProcessorApp
+    from src.config import ConfigManager
+    from src.core import FileProcessor
+    print('✅ Core modules import successfully')
+except ImportError as e:
+    print(f'❌ Import error: {e}')
+    sys.exit(1)
+    
+print('✅ Docker registry image test passed')
+"
           
         else
           echo "🧪 PR validation build - Build completed successfully"


### PR DESCRIPTION
- Remove incorrect indentation from Python script in docker run command
- Python expects no indentation at top level in -c scripts
- Resolves "IndentationError: unexpected indent" in CI Docker image test

🤖 Generated with [Claude Code](https://claude.ai/code)