### PR TITLE
Fix: Sequential Multi-Platform Docker Builds with Proper Manifest Support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -163,30 +163,59 @@ jobs:
       id: platform-tags
       if: inputs.push_image == true
       run: |
+        # Read tags from step output (multi-line format)
         BASE_TAGS="${{ steps.meta.outputs.tags }}"
         AMD64_TAGS=""
         ARM64_TAGS=""
+        FINAL_TAGS=""
 
-        # Convert base tags to platform-specific tags
+        echo "🔍 Processing base tags:"
+        echo "$BASE_TAGS"
+
+        # Convert base tags to platform-specific tags, handling multi-line format
         while IFS= read -r tag; do
-          if [ -n "$tag" ]; then
-            AMD64_TAGS="${AMD64_TAGS}${tag}-amd64,"
-            ARM64_TAGS="${ARM64_TAGS}${tag}-arm64,"
+          # Skip empty lines
+          if [ -n "$tag" ] && [ "$tag" != " " ]; then
+            # Trim whitespace
+            tag=$(echo "$tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+            if [ -n "$tag" ]; then
+              echo "Processing tag: '$tag'"
+
+              # Build platform-specific tags
+              if [ -n "$AMD64_TAGS" ]; then
+                AMD64_TAGS="${AMD64_TAGS},${tag}-amd64"
+                ARM64_TAGS="${ARM64_TAGS},${tag}-arm64"
+              else
+                AMD64_TAGS="${tag}-amd64"
+                ARM64_TAGS="${tag}-arm64"
+              fi
+
+              # Build final tags list
+              if [ -n "$FINAL_TAGS" ]; then
+                FINAL_TAGS="${FINAL_TAGS}
+${tag}"
+              else
+                FINAL_TAGS="${tag}"
+              fi
+            fi
           fi
         done <<< "$BASE_TAGS"
 
-        # Remove trailing commas
-        AMD64_TAGS="${AMD64_TAGS%,}"
-        ARM64_TAGS="${ARM64_TAGS%,}"
-
-        echo "amd64_tags=$AMD64_TAGS" >> $GITHUB_OUTPUT
-        echo "arm64_tags=$ARM64_TAGS" >> $GITHUB_OUTPUT
-        echo "final_tags=$BASE_TAGS" >> $GITHUB_OUTPUT
+        # Set outputs using proper escaping for multi-line
+        {
+          echo "amd64_tags=$AMD64_TAGS"
+          echo "arm64_tags=$ARM64_TAGS"
+          echo "final_tags<<EOF"
+          echo "$FINAL_TAGS"
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
 
         echo "🏷️ Platform-specific tags generated:"
         echo "AMD64: $AMD64_TAGS"
         echo "ARM64: $ARM64_TAGS"
-        echo "Final: $BASE_TAGS"
+        echo "Final tags:"
+        echo "$FINAL_TAGS"
 
     - name: Build AMD64 platform
       id: build-amd64

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -193,8 +193,7 @@ jobs:
 
               # Build final tags list
               if [ -n "$FINAL_TAGS" ]; then
-                FINAL_TAGS="${FINAL_TAGS}
-${tag}"
+                FINAL_TAGS="${FINAL_TAGS}"$'\n'"${tag}"
               else
                 FINAL_TAGS="${tag}"
               fi


### PR DESCRIPTION
## Summary
Complete solution for multi-platform Docker builds that prevents space exhaustion while maintaining proper multi-architecture support:

- **Sequential Platform Builds**: Build AMD64 → cleanup → ARM64 to prevent "no space left on device" errors
- **Proper Multi-Platform Manifests**: Create proper Docker manifests instead of overwriting images
- **Correct Workflow Outputs**: Return multi-platform manifest digest for production builds
- **Robust Tag Parsing**: Handle multi-line tag outputs from docker/metadata-action properly

## Problems Solved

### 1. Space Exhaustion ✅
- **Issue**: "No space left on device" errors during concurrent multi-platform builds
- **Solution**: Sequential builds with aggressive cleanup between platforms

### 2. Manifest Overwrite Bug ✅  
- **Issue**: ARM64 builds overwrote AMD64 builds, breaking multi-platform support
- **Solution**: Platform-specific tags with proper manifest creation

### 3. Incorrect Workflow Output ✅
- **Issue**: Workflow returned AMD64-specific digest instead of manifest digest
- **Solution**: Smart digest selection (manifest for production, AMD64 for PR validation)

### 4. Tag Parsing Error ✅
- **Issue**: Multi-line tags from metadata-action caused "Invalid format" errors  
- **Solution**: Proper multi-line parsing with whitespace handling

## Technical Implementation

### Sequential Build Strategy
```yaml
1. Generate platform-specific tags  → latest-amd64, v1.0.0-amd64, latest-arm64, v1.0.0-arm64
2. Build AMD64 → push to -amd64     → Prevents space issues, pushes AMD64 image
3. Cleanup between builds           → Recycles disk space aggressively  
4. Build ARM64 → push to -arm64     → Prevents space issues, pushes ARM64 image
5. Create multi-platform manifest   → Combines both into proper manifest
6. Push final manifest              → Users get correct architecture automatically
```

### Space Management
- **Pre-build cleanup**: Remove Docker resources, large system directories
- **Between-platform cleanup**: Docker builder/system prune between AMD64 and ARM64
- **Post-build cleanup**: Final cleanup with emergency protocols
- **Reduced cache**: BuildKit cache reduced to 64MB for space efficiency

### Manifest Creation
- Platform-specific images pushed to separate tags (`image:tag-amd64`, `image:tag-arm64`)
- Docker manifest combines both platforms into final tags (`image:tag`, `image:latest`)
- Proper platform annotation (arch: amd64/arm64, os: linux)
- Manifest verification and digest capture for workflow outputs

### Smart Workflow Outputs
- **Production builds**: Return multi-platform manifest digest
- **PR validation**: Return AMD64 platform digest (unchanged behavior)
- **Fallback**: AMD64 digest if manifest creation fails

## Benefits

- **💾 Space Efficient**: Sequential builds prevent disk exhaustion (solves CI failures)
- **🔧 True Multi-Platform**: Proper manifest support for both AMD64 and ARM64
- **⚡ Fast PR Validation**: Single-platform builds for rapid feedback (unchanged)
- **🔒 Reliable**: Robust error handling and fallback mechanisms  
- **🛡️ Backward Compatible**: All existing functionality preserved
- **🎯 Correct Outputs**: Downstream workflows get proper digests for verification

## Testing Strategy

- [x] **Space Management**: Sequential builds prevent "no space left on device"
- [x] **Multi-Platform Support**: Both AMD64 and ARM64 images available via manifest
- [x] **Tag Parsing**: Multi-line tag output handled correctly
- [x] **Workflow Outputs**: Correct digest returned based on build type
- [x] **PR Validation**: Single-platform builds remain fast and unchanged
- [x] **Error Recovery**: Proper fallbacks and error handling

## Files Changed

- **`.github/workflows/docker-build.yml`**: Complete sequential build implementation with manifest support

## Breaking Changes
None - fully backward compatible with existing workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)